### PR TITLE
Update minimum dep to iOS v12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     platforms: [
         // Same baseline as CryptoSwift
         // Increased iOS, tvOS and watchOS because of ISO8601DateFormatter
-        .macOS(.v10_12), .iOS(.v11), .tvOS(.v10), .watchOS(.v3)
+        .macOS(.v10_12), .iOS(.v10), .tvOS(.v10), .watchOS(.v3)
     ],
     products: [
         .library(name: "Paseto", targets: ["Paseto"]),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     name: "Paseto",
     platforms: [
         // Same baseline as CryptoSwift
-        .macOS(.v10_12), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_12), .iOS(.v11), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "Paseto", targets: ["Paseto"]),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
     name: "Paseto",
     platforms: [
         // Same baseline as CryptoSwift
-        .macOS(.v10_12), .iOS(.v12), .tvOS(.v9), .watchOS(.v2)
+        // Increased iOS, tvOS and watchOS because of ISO8601DateFormatter
+        .macOS(.v10_12), .iOS(.v11), .tvOS(.v10), .watchOS(.v3)
     ],
     products: [
         .library(name: "Paseto", targets: ["Paseto"]),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     name: "Paseto",
     platforms: [
         // Same baseline as CryptoSwift
-        .macOS(.v10_12), .iOS(.v11), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_12), .iOS(.v12), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "Paseto", targets: ["Paseto"]),


### PR DESCRIPTION
ISO8601Formatter requires .iOS(.v10) while .sortedKeys requires .iOS(.v11). When the platform version is too low, building fails.