### PR TITLE
Allow public init from P384 PublicKey

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,11 +5,11 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        os: [macos-latest, macos-11, macos-10.15]
+        os: [macos-latest, macos-12, macos-11, macos-10.15]
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Tests
         run: swift test
 
@@ -17,7 +17,7 @@ jobs:
     name: Check Test Vectors Up To Date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check for updates
         run: |
           cd Tests/PasetoTests/TestVectors

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,10 @@
 name: Swift
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   units:
     name: Unit Tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,7 @@ jobs:
   units:
     name: Unit Tests
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, macos-12, macos-11, macos-10.15]
 

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
@@ -8,7 +8,7 @@ extension Version3.Public {
 
         let key: P384.Signing.PublicKey
 
-        var compressed: Bytes {
+        fileprivate static func compress(key: P384.Signing.PublicKey) -> Bytes {
             let x963Representation = key.x963Representation.bytes
 
             guard x963Representation[0] == 04 else {
@@ -47,6 +47,10 @@ extension Version3.Public {
             }
 
             return [prefix] + xBytes
+        }
+
+        var compressed: Bytes {
+            Self.compress(key: key)
         }
 
         public var material: Bytes {

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
@@ -29,6 +29,7 @@ extension Version3.Public {
 
         let key: P384.Signing.PublicKey
 
+        // https://www.secg.org/sec1-v2.pdf
         fileprivate static func decompressToCoords(compressedKey: Bytes) throws -> (x: Bytes, y: Bytes) {
             guard compressedKey.count == 1 + 48 else {
                 throw Exception.badKey("Bad public key length")

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
@@ -60,10 +60,23 @@ extension Version3.Public {
                 )
             }
 
-            guard
-                let key = try? P384.Signing.PublicKey(x963Representation: material) else {
-                throw Exception.badKey("Public key is invalid")
+            if #available(macOS 13, iOS 16, watchOS 9, tvOS 16, macCatalyst 16, *) {
+                guard
+                    let key = try? P384.Signing.PublicKey(compressedRepresentation: material) else {
+                    throw Exception.badKey("Public key is invalid")
+                }
+                self.key = key
+            } else {
+                // Note that this would actually fail on newer versions, so it seems there was a BC break
+                // here which means this constructor will no longer accept compressed points like it once
+                // did.
+                guard
+                    let key = try? P384.Signing.PublicKey(x963Representation: material) else {
+                    throw Exception.badKey("Public key is invalid")
+                }
+                self.key = key
             }
+        }
 
             self.key = key
         }

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
@@ -38,7 +38,7 @@ extension Version3.Public {
 
             // 2.1
             let prefix = compressedKey[0]
-            let x = compressedKey[1...].bytes
+            let x = compressedKey[1..<49].bytes
 
             // 2.2
             let xBn = BigUInteger(Data(x))

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
@@ -68,7 +68,7 @@ extension Version3.Public {
             self.key = key
         }
 
-        init (key: P384.Signing.PublicKey) {
+        public init (key: P384.Signing.PublicKey) {
             self.key = key
         }
     }

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
@@ -1,5 +1,26 @@
 import Foundation
 import CryptoKit
+import CryptoSwift
+
+fileprivate let zeroBn = BigUInteger(0)
+fileprivate let oneBn = BigUInteger(1)
+fileprivate let twoBn = BigUInteger(2)
+fileprivate let fourBn = BigUInteger(4)
+
+// The following consts are extracted from the NIST spec.
+// https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-186-draft.pdf
+
+// p = 2^384 − 2^128 − 2^96 + 2^32 − 1
+fileprivate let pBn = twoBn.power(384) - twoBn.power(128) - twoBn.power(96) + twoBn.power(32) - 1
+
+// a = -3 mod p
+//   = 3940200619639447921227904010014361380507973927046544666794\
+//     8293404245721771496870329047266088258938001861606973112316
+fileprivate let aBn = BigUInteger("39402006196394479212279040100143613805079739270465446667948293404245721771496870329047266088258938001861606973112316", radix: 10)!
+
+// b = 2758019355995970587784901184038904809305690585636156852142\
+//     8707301988689241309860865136260764883745107765439761230575
+fileprivate let bBn = BigUInteger("27580193559959705877849011840389048093056905856361568521428707301988689241309860865136260764883745107765439761230575", radix: 10)!
 
 @available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 extension Version3.Public {
@@ -7,6 +28,60 @@ extension Version3.Public {
         public static let length = 49
 
         let key: P384.Signing.PublicKey
+
+        fileprivate static func decompressToCoords(compressedKey: Bytes) throws -> (x: Bytes, y: Bytes) {
+            guard compressedKey.count == 1 + 48 else {
+                throw Exception.badKey("Bad public key length")
+            }
+
+            if compressedKey == Bytes(repeating: 0, count: 49) {
+                return (x: Bytes(repeating: 0, count: 48), y: Bytes(repeating: 0, count: 48))
+            }
+
+            let prefix = compressedKey[0]
+            let x = compressedKey[1...].bytes
+
+            let yTildeP: BigUInteger
+            switch prefix {
+            case 02:
+                yTildeP = zeroBn
+            case 03:
+                yTildeP = oneBn
+            default:
+                throw Exception.badKey("Bad public key prefix")
+            }
+
+            let xBn = BigUInteger(Data(x))
+
+            let alpha = (xBn.power(3) + (aBn * xBn) + bBn) % pBn
+
+            // Take square root mod p
+            // https://en.wikipedia.org/wiki/Tonelli%E2%80%93Shanks_algorithm
+            // For prime p = 3 (mod 4), r = n ^ ((p+1)/n) (mod p) is a root of r^2 = n (mod p)
+            let beta = alpha.power((pBn + 1)/4, modulus: pBn)
+
+            let yBn: BigUInteger
+            if beta % 2 == yTildeP {
+                yBn = beta
+            } else {
+                yBn = pBn - beta
+            }
+
+            let y = Bytes(yBn.serialize())
+
+            guard y.count <= 48 else {
+                throw Exception.badKey("Invalid y byte length")
+            }
+
+            let yPadded = Bytes(repeating: 0, count: 48 - y.count) + y
+
+            return (x, yPadded)
+        }
+
+        fileprivate static func decompress(compressedKey: Bytes) throws -> P384.Signing.PublicKey {
+            let (x, y) = try decompressToCoords(compressedKey: compressedKey)
+            return try P384.Signing.PublicKey(rawRepresentation: x + y)
+        }
 
         fileprivate static func compress(key: P384.Signing.PublicKey) -> Bytes {
             let x963Representation = key.x963Representation.bytes
@@ -64,22 +139,7 @@ extension Version3.Public {
                 )
             }
 
-            if #available(macOS 13, iOS 16, watchOS 9, tvOS 16, macCatalyst 16, *) {
-                guard
-                    let key = try? P384.Signing.PublicKey(compressedRepresentation: material) else {
-                    throw Exception.badKey("Public key is invalid")
-                }
-                self.key = key
-            } else {
-                // Note that this would actually fail on newer versions, so it seems there was a BC break
-                // here which means this constructor will no longer accept compressed points like it once
-                // did.
-                guard
-                    let key = try? P384.Signing.PublicKey(x963Representation: material) else {
-                    throw Exception.badKey("Public key is invalid")
-                }
-                self.key = key
-            }
+            self.key = try Self.decompress(compressedKey: material)
         }
 
         init (_ key: P384.Signing.PublicKey) {

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
@@ -58,8 +58,13 @@ extension Version3.Public {
 
             // Take square root mod p
             // https://en.wikipedia.org/wiki/Tonelli%E2%80%93Shanks_algorithm
-            // For prime p = 3 (mod 4), r = n ^ ((p+1)/n) (mod p) is a root of r^2 = n (mod p)
+            // For prime p = 3 (mod 4), r = n ^ ((p+1)/n) (mod p) is a root of r^2 = n (mod p), if a square root exists
             let beta = alpha.power((pBn + 1)/4, modulus: pBn)
+
+            // check square root exists
+            guard beta.power(2, modulus: pBn) == alpha else {
+                throw Exception.badKey("Square root not found")
+            }
 
             let yBn: BigUInteger
             if beta % 2 == yTildeP {

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
@@ -87,6 +87,7 @@ extension Version3.Public {
             // prefix pad y bytes to fill 48 bytes
             let yPadded = Bytes(repeating: 0, count: 48 - y.count) + y
 
+            // 2.5
             return (x, yPadded)
         }
 

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricSecretKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricSecretKey.swift
@@ -46,9 +46,7 @@ extension Version3.Public.AsymmetricSecretKey: Paseto.AsymmetricSecretKey {
     }
 
     public var publicKey: Version3.Public.AsymmetricPublicKey {
-        return Version3.Public.AsymmetricPublicKey (
-            key: key.publicKey
-        )
+        return Version3.Public.AsymmetricPublicKey(key.publicKey)
     }
 }
 

--- a/Tests/PasetoTests/KeyTest.swift
+++ b/Tests/PasetoTests/KeyTest.swift
@@ -5,13 +5,17 @@ import Sodium
 
 class KeyTest: XCTestCase {
     func testInvalidKeyImport() {
-        let material = sodium.utils.hex2bin( "04fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fbfbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb")!
-        
-        // import invalid key
-        let pubKey = try! P384.Signing.PublicKey(x963Representation: material)
-        
-        // should detect invalid key
-        XCTAssertThrowsError(try Paseto.Version3.AsymmetricPublicKey(key: pubKey))
+        if #available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *) {
+            let material = sodium.utils.hex2bin( "04fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fbfbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb")!
+
+            // import invalid key
+            let pubKey = try! P384.Signing.PublicKey(x963Representation: material)
+
+            // should detect invalid key
+            XCTAssertThrowsError(try Paseto.Version3.AsymmetricPublicKey(key: pubKey))
+        } else {
+            _ = XCTSkip("Skipping key test where key is not supported")
+        }
     }
 }
 

--- a/Tests/PasetoTests/KeyTest.swift
+++ b/Tests/PasetoTests/KeyTest.swift
@@ -15,6 +15,7 @@ class KeyTest: XCTestCase {
         XCTAssertThrowsError(try Paseto.Version3.AsymmetricPublicKey(key: pubKey))
     }
 
+#if compiler(>=5.7)
     @available(macOS 13, *)
     func testGeneratedKeyImport() {
         for _ in 1...100 {
@@ -39,5 +40,6 @@ class KeyTest: XCTestCase {
             XCTAssertEqual(pubKey?.rawRepresentation.bytes, pasetoPubKey?.key.rawRepresentation.bytes)
         }
     }
+#endif
 }
 

--- a/Tests/PasetoTests/KeyTest.swift
+++ b/Tests/PasetoTests/KeyTest.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import Paseto
+import CryptoKit
+import Sodium
+
+class KeyTest: XCTestCase {
+    func testInvalidKeyImport() {
+        let material = sodium.utils.hex2bin( "04fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fbfbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb")!
+        
+        // import invalid key
+        let pubKey = try! P384.Signing.PublicKey(x963Representation: material)
+        
+        // should detect invalid key
+        XCTAssertThrowsError(try Paseto.Version3.AsymmetricPublicKey(key: pubKey))
+    }
+}
+

--- a/Tests/PasetoTests/KeyTest.swift
+++ b/Tests/PasetoTests/KeyTest.swift
@@ -4,48 +4,39 @@ import CryptoKit
 import Sodium
 
 class KeyTest: XCTestCase {
+    @available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
     func testInvalidKeyImport() {
-        if #available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *) {
-            let material = sodium.utils.hex2bin( "04fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fbfbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb")!
+        let material = sodium.utils.hex2bin( "04fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fbfbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb")!
 
-            // import invalid key
-            let pubKey = try! P384.Signing.PublicKey(x963Representation: material)
+        // import invalid key
+        let pubKey = try! P384.Signing.PublicKey(x963Representation: material)
 
-            // should detect invalid key
-            XCTAssertThrowsError(try Paseto.Version3.AsymmetricPublicKey(key: pubKey))
-        } else {
-            _ = XCTSkip("Skipping key test where key is not supported")
-        }
+        // should detect invalid key
+        XCTAssertThrowsError(try Paseto.Version3.AsymmetricPublicKey(key: pubKey))
     }
 
+    @available(macOS 13, *)
     func testGeneratedKeyImport() {
-        if #available(macOS 13, *) {
-            for _ in 1...100 {
-                let privKey = P384.Signing.PrivateKey(compactRepresentable: false)
+        for _ in 1...100 {
+            let privKey = P384.Signing.PrivateKey(compactRepresentable: false)
 
-                let pubKey = privKey.publicKey
+            let pubKey = privKey.publicKey
 
-                let pasetoPubKey = Paseto.Version3.AsymmetricPublicKey(bytes: pubKey.compressedRepresentation)!
+            let pasetoPubKey = Paseto.Version3.AsymmetricPublicKey(bytes: pubKey.compressedRepresentation)!
 
-                XCTAssertEqual(pubKey.rawRepresentation.bytes, pasetoPubKey.key.rawRepresentation.bytes)
-            }
-        } else {
-            _ = XCTSkip("Skipping key test where key is not supported")
+            XCTAssertEqual(pubKey.rawRepresentation.bytes, pasetoPubKey.key.rawRepresentation.bytes)
         }
     }
 
+    @available(macOS 13, *)
     func testRandomKeyImport() {
-        if #available(macOS 13, *) {
-            for _ in 1...100 {
-                let bytes = [Util.random(length: 1)[0] % 2 == 0 ? 02 : 03] + Util.random(length: 48)
+        for _ in 1...100 {
+            let bytes = [Util.random(length: 1)[0] % 2 == 0 ? 02 : 03] + Util.random(length: 48)
 
-                let pasetoPubKey = Paseto.Version3.AsymmetricPublicKey(bytes: bytes)
-                let pubKey = try? P384.Signing.PublicKey(compressedRepresentation: bytes)
+            let pasetoPubKey = Paseto.Version3.AsymmetricPublicKey(bytes: bytes)
+            let pubKey = try? P384.Signing.PublicKey(compressedRepresentation: bytes)
 
-                XCTAssertEqual(pubKey?.rawRepresentation.bytes, pasetoPubKey?.key.rawRepresentation.bytes)
-            }
-        } else {
-            _ = XCTSkip("Skipping key test where key is not supported")
+            XCTAssertEqual(pubKey?.rawRepresentation.bytes, pasetoPubKey?.key.rawRepresentation.bytes)
         }
     }
 }

--- a/Tests/PasetoTests/KeyTest.swift
+++ b/Tests/PasetoTests/KeyTest.swift
@@ -17,5 +17,36 @@ class KeyTest: XCTestCase {
             _ = XCTSkip("Skipping key test where key is not supported")
         }
     }
+
+    func testGeneratedKeyImport() {
+        if #available(macOS 13, *) {
+            for _ in 1...100 {
+                let privKey = P384.Signing.PrivateKey(compactRepresentable: false)
+
+                let pubKey = privKey.publicKey
+
+                let pasetoPubKey = Paseto.Version3.AsymmetricPublicKey(bytes: pubKey.compressedRepresentation)!
+
+                XCTAssertEqual(pubKey.rawRepresentation.bytes, pasetoPubKey.key.rawRepresentation.bytes)
+            }
+        } else {
+            _ = XCTSkip("Skipping key test where key is not supported")
+        }
+    }
+
+    func testRandomKeyImport() {
+        if #available(macOS 13, *) {
+            for _ in 1...100 {
+                let bytes = [Util.random(length: 1)[0] % 2 == 0 ? 02 : 03] + Util.random(length: 48)
+
+                let pasetoPubKey = Paseto.Version3.AsymmetricPublicKey(bytes: bytes)
+                let pubKey = try? P384.Signing.PublicKey(compressedRepresentation: bytes)
+
+                XCTAssertEqual(pubKey?.rawRepresentation.bytes, pasetoPubKey?.key.rawRepresentation.bytes)
+            }
+        } else {
+            _ = XCTSkip("Skipping key test where key is not supported")
+        }
+    }
 }
 


### PR DESCRIPTION
This allows to initialize a public key directly from a P384 Public Key. 

In my case, I have a PEM file as public key, which I read from a file and then I need to initialize `Version3.AsymmetricPublicKey`.

```swift
let publicKeyPem = try String(contentsOf: Bundle.main.resourceURL!.appendingPathComponent("ios.paseto.pub"), encoding: String.Encoding.utf8)
let publicKey = try P384.Signing.PublicKey.init(pemRepresentation: publicKeyPem)
let key = try Version3.AsymmetricPublicKey.init(key: publicKey)
let token = try self.pasetoParser.verify(encodedToken, with: key)
```