### PR TITLE
Upgrade to Swift sodium 0.10.0

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,5 +28,5 @@ jobs:
         run: |
           cd Tests/PasetoTests/TestVectors
           rm *
-          wget https://raw.githubusercontent.com/paseto-standard/test-vectors/master/v{1..4}.json
+          wget https://raw.githubusercontent.com/paseto-standard/test-vectors/master/v{1,2,3,4}.json
           git diff --exit-code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-12, macos-11, macos-10.15]
+        os: [macos-latest, macos-15, macos-14]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 //
 //  Package.swift
 //  Paseto
@@ -15,14 +15,13 @@ let package = Package(
     platforms: [
         // Same baseline as CryptoSwift
         // Increased iOS, tvOS and watchOS because of ISO8601DateFormatter
-        .macOS(.v10_12), .iOS(.v10), .tvOS(.v10), .watchOS(.v3)
+        .macOS(.v14), .iOS(.v15), .tvOS(.v12), .watchOS(.v4)
     ],
     products: [
         .library(name: "Paseto", targets: ["Paseto"]),
     ],
     dependencies: [
         .package(
-            name: "Sodium",
             url: "https://github.com/jedisct1/swift-sodium.git",
             .upToNextMajor(from: "0.10.0")
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -51,5 +51,5 @@ let package = Package(
             ]
         ),
     ],
-    swiftLanguageModes: [.v5]
+    swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:5.9
 //
 //  Package.swift
 //  Paseto

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.1
 //
 //  Package.swift
 //  Paseto
@@ -15,7 +15,7 @@ let package = Package(
     platforms: [
         // Same baseline as CryptoSwift
         // Increased iOS, tvOS and watchOS because of ISO8601DateFormatter
-        .macOS(.v14), .iOS(.v15), .tvOS(.v12), .watchOS(.v4)
+        .macOS(.v14), .iOS(.v15), .tvOS(.v18), .watchOS(.v11)
     ],
     products: [
         .library(name: "Paseto", targets: ["Paseto"]),
@@ -38,8 +38,7 @@ let package = Package(
         .target(
             name: "Paseto",
             dependencies: [
-                .product(name: "Clibsodium", package: "Sodium"),
-                .product(name: "Sodium", package: "Sodium"),
+                .product(name: "Sodium", package: "swift-sodium"),
                 "CryptoSwift",
                 "TypedJSON"
             ]
@@ -52,5 +51,5 @@ let package = Package(
             ]
         ),
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageModes: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     platforms: [
         // Same baseline as CryptoSwift
         // Increased iOS, tvOS and watchOS because of ISO8601DateFormatter
-        .macOS(.v14), .iOS(.v15), .tvOS(.v18), .watchOS(.v11)
+        .macOS(.v14), .iOS(.v15), .tvOS(.v17), .watchOS(.v10)
     ],
     products: [
         .library(name: "Paseto", targets: ["Paseto"]),

--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,8 @@ let package = Package(
     dependencies: [
         .package(
             name: "Sodium",
-            url: "https://github.com/aidantwoods/swift-sodium.git",
-            .branch("full-clibsodium-build")
+            url: "https://github.com/jedisct1/swift-sodium.git",
+            .upToNextMajor(from: "0.10.0")
         ),
         .package(
             url: "https://github.com/krzyzanowskim/CryptoSwift.git",

--- a/README.md
+++ b/README.md
@@ -200,8 +200,6 @@ Version 4 is fully supported.
 ## Version 3
 Version 3 is fully supported.
 
-> Note: Support for public mode requires `@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)`.
-
 ## Version 2
 Version 2 is fully supported.
 

--- a/Sources/Paseto/Implementations/Version.swift
+++ b/Sources/Paseto/Implementations/Version.swift
@@ -7,27 +7,15 @@ public enum Version: String {
 
 extension Version {
     init <M: Module>(module: M.Type) {
-        if #available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *) {
-            switch module {
-            case is Version1.Local.Type: self = .v1
-            case is Version2.Local.Type: self = .v2
-            case is Version2.Public.Type: self = .v2
-            case is Version3.Local.Type: self = .v3
-            case is Version3.Public.Type: self = .v3
-            case is Version4.Local.Type: self = .v4
-            case is Version4.Public.Type: self = .v4
-            default: fatalError("All implementations must be enumerated")
-            }
-        } else {
-            switch module {
-            case is Version1.Local.Type: self = .v1
-            case is Version2.Local.Type: self = .v2
-            case is Version2.Public.Type: self = .v2
-            case is Version3.Local.Type: self = .v3
-            case is Version4.Local.Type: self = .v4
-            case is Version4.Public.Type: self = .v4
-            default: fatalError("All implementations must be enumerated")
-            }
+        switch module {
+        case is Version1.Local.Type: self = .v1
+        case is Version2.Local.Type: self = .v2
+        case is Version2.Public.Type: self = .v2
+        case is Version3.Local.Type: self = .v3
+        case is Version3.Public.Type: self = .v3
+        case is Version4.Local.Type: self = .v4
+        case is Version4.Public.Type: self = .v4
+        default: fatalError("All implementations must be enumerated")
         }
     }
 }

--- a/Sources/Paseto/Implementations/Version3.swift
+++ b/Sources/Paseto/Implementations/Version3.swift
@@ -3,7 +3,6 @@ import Foundation
 public enum Version3 {
     public struct Local {}
 
-    @available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
     public struct Public {}
 }
 
@@ -17,7 +16,6 @@ extension Version3: DeferredLocal {
     public typealias SymmetricKey = Local.SymmetricKey
 }
 
-@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 extension Version3: DeferredPublic {
     public typealias AsymmetricSecretKey = Public.AsymmetricSecretKey
     public typealias AsymmetricPublicKey = Public.AsymmetricPublicKey

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricPublicKey.swift
@@ -22,7 +22,6 @@ fileprivate let aBn = BigUInteger("394020061963944792122790401001436138050797392
 //     8707301988689241309860865136260764883745107765439761230575
 fileprivate let bBn = BigUInteger("27580193559959705877849011840389048093056905856361568521428707301988689241309860865136260764883745107765439761230575", radix: 10)!
 
-@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 extension Version3.Public {
     public struct AsymmetricPublicKey  {
         public static let length = 49
@@ -183,12 +182,10 @@ extension Version3.Public {
     }
 }
 
-@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 extension Version3.Public.AsymmetricPublicKey : Paseto.AsymmetricPublicKey {
     public typealias Module = Version3.Public
 }
 
-@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 public extension Version3.Public.AsymmetricPublicKey  {
     enum Exception: Error {
         case badLength(String)

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricSecretKey.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicAsymmetricSecretKey.swift
@@ -1,7 +1,6 @@
 import Foundation
 import CryptoKit
 
-@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 extension Version3.Public {
     public struct AsymmetricSecretKey {
         public static let length = 48
@@ -36,7 +35,6 @@ extension Version3.Public {
     }
 }
 
-@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 extension Version3.Public.AsymmetricSecretKey: Paseto.AsymmetricSecretKey {
     public typealias Module = Version3.Public
 
@@ -50,7 +48,6 @@ extension Version3.Public.AsymmetricSecretKey: Paseto.AsymmetricSecretKey {
     }
 }
 
-@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 extension Version3.Public.AsymmetricSecretKey {
     enum Exception: Error {
         case badLength(String)

--- a/Sources/Paseto/Implementations/Version3/Public/V3PublicPayload.swift
+++ b/Sources/Paseto/Implementations/Version3/Public/V3PublicPayload.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 extension Version3.Public: Module {
     public struct Payload {
         static let signatureLength = 96
@@ -10,7 +9,6 @@ extension Version3.Public: Module {
     }
 }
 
-@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 extension Version3.Public.Payload: Paseto.Payload {
     public var bytes: Bytes { return message + signature }
 

--- a/Sources/Paseto/Implementations/Version3/V3Public.swift
+++ b/Sources/Paseto/Implementations/Version3/V3Public.swift
@@ -1,7 +1,6 @@
 import Foundation
 import CryptoKit
 
-@available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
 extension Version3.Public: BasePublic {
     public typealias Public = Version3.Public
 

--- a/Tests/PasetoTests/KeyTest.swift
+++ b/Tests/PasetoTests/KeyTest.swift
@@ -5,7 +5,6 @@ import Sodium
 
 class KeyTest: XCTestCase {
 #if compiler(>=5.7)
-    @available(macOS 13, *)
     func testGeneratedKeyImport() {
         for _ in 1...100 {
             let privKey = P384.Signing.PrivateKey(compactRepresentable: false)
@@ -18,7 +17,6 @@ class KeyTest: XCTestCase {
         }
     }
 
-    @available(macOS 13, *)
     func testRandomKeyImport() {
         for _ in 1...100 {
             let bytes = [Util.random(length: 1)[0] % 2 == 0 ? 02 : 03] + Util.random(length: 48)

--- a/Tests/PasetoTests/KeyTest.swift
+++ b/Tests/PasetoTests/KeyTest.swift
@@ -4,17 +4,6 @@ import CryptoKit
 import Sodium
 
 class KeyTest: XCTestCase {
-    @available(macOS 11, iOS 14, watchOS 7, tvOS 14, macCatalyst 14, *)
-    func testInvalidKeyImport() {
-        let material = sodium.utils.hex2bin( "04fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fbfbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb")!
-
-        // import invalid key
-        let pubKey = try! P384.Signing.PublicKey(x963Representation: material)
-
-        // should detect invalid key
-        XCTAssertThrowsError(try Paseto.Version3.AsymmetricPublicKey(key: pubKey))
-    }
-
 #if compiler(>=5.7)
     @available(macOS 13, *)
     func testGeneratedKeyImport() {

--- a/Tests/PasetoTests/KeyTest.swift
+++ b/Tests/PasetoTests/KeyTest.swift
@@ -4,7 +4,6 @@ import CryptoKit
 import Sodium
 
 class KeyTest: XCTestCase {
-#if compiler(>=5.7)
     func testGeneratedKeyImport() {
         for _ in 1...100 {
             let privKey = P384.Signing.PrivateKey(compactRepresentable: false)
@@ -27,6 +26,4 @@ class KeyTest: XCTestCase {
             XCTAssertEqual(pubKey?.rawRepresentation.bytes, pasetoPubKey?.key.rawRepresentation.bytes)
         }
     }
-#endif
 }
-

--- a/Tests/PasetoTests/TestVectors/v3.json
+++ b/Tests/PasetoTests/TestVectors/v3.json
@@ -98,7 +98,7 @@
       "secret-key": "20347609607477aca8fbfbc5e6218455f3199669792ef8b466faa87bdc67798144c848dd03661eed5ac62461340cea96",
       "secret-key-pem": "-----BEGIN EC PRIVATE KEY-----\nMIGkAgEBBDAgNHYJYHR3rKj7+8XmIYRV8xmWaXku+LRm+qh73Gd5gUTISN0DZh7t\nWsYkYTQM6pagBwYFK4EEACKhZANiAAT7y3xp7hxgV5vnozQTSHjZxcW/NdVS2rY8\nAUA5ftFM72N9dyCSXERpnqMOcodMcvt8kgcrB8KcKee0HU23E79/s4CvEs8hBfnj\nSUd/gcAm08EjSIz06iWjrNy4NakxR3I=\n-----END EC PRIVATE KEY-----",
       "public-key-pem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+8t8ae4cYFeb56M0E0h42cXFvzXVUtq2\nPAFAOX7RTO9jfXcgklxEaZ6jDnKHTHL7fJIHKwfCnCnntB1NtxO/f7OArxLPIQX5\n40lHf4HAJtPBI0iM9Oolo6zcuDWpMUdy\n-----END PUBLIC KEY-----",
-      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9qqEwwrKHKi5lJ7b9MBKc0G4MGZy0ptUiMv3lAUAaz-JY_zjoqBSIxMxhfAoeNYiSyvfUErj76KOPWm1OeNnBPkTSespeSXDGaDfxeIrl3bRrPEIy7tLwLAIsRzsXkfph",
+      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9vrarT0tBPumLsUh5iJGDDH7sIkPk1fW8Ej6R2j-8jB7rkkCJyEKxcMNPJ5jLurPvZSzRdLb-Ia_Y2YXavY77xbLzJQJkA_zjJeYrd8mWQ24oOpkts1Css3Xa74cz_j3A",
       "payload": "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
       "footer": "",
       "implicit-assertion": ""
@@ -122,7 +122,7 @@
       "secret-key": "20347609607477aca8fbfbc5e6218455f3199669792ef8b466faa87bdc67798144c848dd03661eed5ac62461340cea96",
       "secret-key-pem": "-----BEGIN EC PRIVATE KEY-----\nMIGkAgEBBDAgNHYJYHR3rKj7+8XmIYRV8xmWaXku+LRm+qh73Gd5gUTISN0DZh7t\nWsYkYTQM6pagBwYFK4EEACKhZANiAAT7y3xp7hxgV5vnozQTSHjZxcW/NdVS2rY8\nAUA5ftFM72N9dyCSXERpnqMOcodMcvt8kgcrB8KcKee0HU23E79/s4CvEs8hBfnj\nSUd/gcAm08EjSIz06iWjrNy4NakxR3I=\n-----END EC PRIVATE KEY-----",
       "public-key-pem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+8t8ae4cYFeb56M0E0h42cXFvzXVUtq2\nPAFAOX7RTO9jfXcgklxEaZ6jDnKHTHL7fJIHKwfCnCnntB1NtxO/f7OArxLPIQX5\n40lHf4HAJtPBI0iM9Oolo6zcuDWpMUdy\n-----END PUBLIC KEY-----",
-      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ94SjWIbjmS7715GjLSnHnpJrC9Z-cnwK45dmvnVvCRQDCCKAXaKEopTajX0DKYx1Xqr6gcTdfqscLCAbiB4eOW9jlt-oNqdG8TjsYEi6aloBfTzF1DXff_45tFlnBukEX.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9",
+      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9FrkqK6FaB39LisqmPmIHLnu5P8zBTdO_EyWqeworXkGMBChHk-ZZWPt2r7qSYpOqWmvf0oBgf9Elx1TKS4a3YKIcaYddPlu6B9w5LT_b76sCqdVDjE5bH8ZgvZ708c48.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9",
       "payload": "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
       "footer": "{\"kid\":\"dYkISylxQeecEcHELfzF88UZrwbLolNiCdpzUHGw9Uqn\"}",
       "implicit-assertion": "{\"test-vector\":\"3-S-3\"}"


### PR DESCRIPTION
This PR upgrades [Swift Sodium to 0.10.0](https://github.com/jedisct1/swift-sodium/releases/tag/0.10.0) and does some additional package maintenance. Platform versions are updated and not necessary `@available` and `#if compiler` are removed. Finally, the test vectors are upgraded to latest available.

Fixes #22 and supersedes #20.